### PR TITLE
Fix `homeDirectory` path is not correct

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,7 +124,7 @@
         }:
         homeManagerConfiguration rec {
           inherit system username;
-          homeDirectory = "/${homePrefix system}/${username}";
+          homeDirectory = "${homePrefix system}/${username}";
           extraSpecialArgs = { inherit inputs lib; };
           configuration = {
             imports = baseModules ++ extraModules


### PR DESCRIPTION
This PR fix a double slash mistake in `homeDirectory` attribute, ex: `//home/kclejeune` should be `/home/kclejeune`