### PR TITLE
Explicitly name the build system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,7 +90,7 @@
         , extraModules ? [ ]
         }:
         darwinSystem {
-          # system = "x86_64-darwin";
+          system = "x86_64-darwin";
           modules = baseModules ++ extraModules
             ++ [{ nixpkgs.overlays = overlays; }];
           specialArgs = { inherit inputs lib; };


### PR DESCRIPTION
According to this commit https://github.com/LnL7/nix-darwin/commit/e1a3f7292f085fd588d11f94ed0f47968c16df0c, we have to explicitly name the system we'd like to build